### PR TITLE
[SUBS-1120] Remove unnecessary web environment configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'uk.ac.ebi.subs'
-version '2.0.0-SNAPSHOT'
+version '2.0.1-SNAPSHOT'
 
 buildscript {
     repositories {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.main.web-environment=false


### PR DESCRIPTION
subs-data-model is a library. It won't ever been executed as an application, so we don't need this setting. This setting also causes some issues (Tomcat is not starting up) with application using this library; specially when they are using an application.yml file for configuration.

