### PR TITLE
add name to Submitter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'uk.ac.ebi.subs'
-version '2.2.0-SNAPSHOT'
+version '2.3.0-SNAPSHOT'
 
 buildscript {
     repositories {

--- a/src/main/java/uk/ac/ebi/subs/data/component/Submitter.java
+++ b/src/main/java/uk/ac/ebi/subs/data/component/Submitter.java
@@ -7,7 +7,8 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 public class Submitter {
-    String email;
+    private String email;
+    private String name;
 
     public String getEmail() {
         return email;


### PR DESCRIPTION
This allows us to pass the submitter name around the system, e.g. to archive agents